### PR TITLE
seo: add sitemap, robots, metadataBase and Organization JSON-LD

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,7 +7,10 @@ import GoogleTagManager from '@/components/GoogleTagManager';
 
 const inter = Inter({ subsets: ['latin'] });
 
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.fiscet.it';
+
 export const metadata: Metadata = {
+  metadataBase: new URL(BASE_URL),
   title: 'Fullstack Applications Next.js, Payload CMS, Sanity & Strapi',
   description:
     'Custom web applications built with Next.js, leveraging headless CMS solutions like Payload CMS, Sanity.io, and Strapi. Fast, scalable, and user-friendly digital solutions for your business with modern tech stack.',
@@ -19,7 +22,7 @@ export const metadata: Metadata = {
       'Custom web applications built with Next.js, leveraging headless CMS solutions like Payload CMS, Sanity.io, and Strapi. Fast, scalable, and user-friendly digital solutions for your business with modern tech stack.',
     type: 'website',
     locale: 'en_US',
-    siteName: 'Your Company Name'
+    siteName: 'Fiscet',
   },
   twitter: {
     card: 'summary_large_image',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { PageTitle } from '@/components/PageTitle';
 import AboutSection from '@/components/AboutSection';
 import HomeSection from '@/components/home/HomeSection';
@@ -7,9 +8,36 @@ import ContactSection from '@/components/contact/ContactSection';
 import Footer from '@/components/Footer';
 import HashScroll from '@/components/HashScroll';
 
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.fiscet.it';
+
+export const metadata: Metadata = {
+  alternates: { canonical: BASE_URL },
+};
+
+const organizationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'Fiscet',
+  url: BASE_URL,
+  description:
+    'Custom web applications built with Next.js and headless CMS solutions like Payload CMS, Sanity.io, and Strapi.',
+  founder: {
+    '@type': 'Person',
+    name: 'Christian Zanchetta',
+    url: 'https://www.linkedin.com/in/christian-zanchetta-a7140621/?locale=en-US',
+  },
+  sameAs: [
+    'https://www.linkedin.com/in/christian-zanchetta-a7140621/?locale=en-US',
+  ],
+};
+
 export default function HomePage() {
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
+      />
       <HashScroll />
       <div className="container mx-auto flex flex-col p-4 mb-4">
         <PageTitle className="text-center">

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from 'next';
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.fiscet.it';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: '/api/',
+    },
+    sitemap: `${BASE_URL}/sitemap.xml`,
+    host: BASE_URL,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,36 @@
+import type { MetadataRoute } from 'next';
+import { getPublishedPosts } from '@/lib/blog';
+
+const BASE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.fiscet.it';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const posts = getPublishedPosts();
+
+  const lastBlogUpdate = posts[0]?.publishedAt
+    ? new Date(posts[0].publishedAt)
+    : new Date();
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+    {
+      url: `${BASE_URL}/blog`,
+      lastModified: lastBlogUpdate,
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+  ];
+
+  const postRoutes: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: `${BASE_URL}/blog/${post.slug}`,
+    lastModified: new Date(post.publishedAt),
+    changeFrequency: 'monthly',
+    priority: 0.6,
+  }));
+
+  return [...staticRoutes, ...postRoutes];
+}


### PR DESCRIPTION
- add dynamic app/sitemap.ts (home, blog index, published posts)
- add app/robots.ts referencing the sitemap, disallowing /api/
- set metadataBase and fix placeholder siteName -> Fiscet in root layout
- add canonical + Organization JSON-LD to the home page